### PR TITLE
fix - tejr/vim-tmux doesn't exist anymore on GitHub

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -29,7 +29,7 @@ endif
 " filetype plugins
 Plug 'vim-ruby/vim-ruby'
 Plug 'elzr/vim-json', {'for' : 'json'}
-Plug 'tejr/vim-tmux', {'for': 'tmux'}
+Plug 'tmux-plugins/vim-tmux', {'for': 'tmux'}
 Plug 'ekalinin/Dockerfile.vim', {'for' : 'Dockerfile'}
 Plug 'fatih/vim-nginx' , {'for' : 'nginx'}
 Plug 'corylanou/vim-present', {'for' : 'present'}


### PR DESCRIPTION
I was trying to configure my Vim, especially for working with vim-go as it is best utility there. ;)
Problem I found out when trying to use [.vimrc](https://github.com/fatih/dotfiles/blob/master/vimrc) is at line 32 of it:
```
Plug 'tejr/vim-tmux', {'for': 'tmux'}
```
[tejr](https://github.com/tejr) is not anymore using GitHub for hosting repositories. When every I try to execute `:PlugInstall`, following will arise:
```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```
![fatal error](http://i.imgur.com/VZEq8Ln.png)
Trying to open [tejr/vim-tmux](https://github.com/tejr/vim-tmux) gives not found error.
As `tejr` is using some [other SVN solution (from his profile description)](https://sanctum.geek.nz/cgit/vim-tmux.git/).
If I try to use clone link for `Plug` directive (https://sanctum.geek.nz/code/vim-tmux.git), it will give error:
```
fatal: dump http transport does not support --depth
```
I tried some of possibilities, e.g. one of them:
```
Plug 'https://sanctum.geek.nz/code/vim-tmux.git', {'for': 'tmux'}
```
![fatal error](http://i.imgur.com/cpiltLp.png)

I found alternative for it so, I want to discuss about it, is it worth it?
[tmux-plugins/vim-tmux](https://github.com/tmux-plugins/vim-tmux), it is also fork from [Zaiste](https://github.com/zaiste), and I hope it have same functionality as original is not easy accessible.

If I'm missing something, well... :P