### PR TITLE
Add iTerm to tmux window keybindings

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -368,6 +368,9 @@ key_bindings:
   - { key: K,        mods: Command,       chars: "\x06\x6b" }
   - { key: L,        mods: Command,       chars: "\x06\x6c" }
   - { key: T,        mods: Command,       chars: "\x06\x63" }
+  - { key: RBracket, mods: Command|Shift, chars: "\x06\x6e" }
+  - { key: LBracket, mods: Command|Shift, chars: "\x06\x70" }
+  - { key: Return,   mods: Command|Shift, chars: "\x06\x7a" }
   - { key: Key1,     mods: Command,       chars: "\x06\x31" }
   - { key: Key2,     mods: Command,       chars: "\x06\x32" }
   - { key: Key3,     mods: Command,       chars: "\x06\x33" }


### PR DESCRIPTION
These are typical OSX default keybindings that also work in iTerm so it is quite handy to map them to their tmux equivalents in alacritty.

Select Next Tab﻿﻿		⇧⌘]
Select Previous Tab	⇧⌘[
Maximise Active Pane	⇧⌘↩

(as discussed, feel free to dismiss PRs if the additions do not interest you)