### PR TITLE
Remove custom mapping to favor <C-g>

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -257,9 +257,6 @@ map <C-k> <C-W>k
 map <C-h> <C-W>h
 map <C-l> <C-W>l
 
-" Print full path
-map <C-f> :echo expand("%:p")<cr>
-
 " Terminal settings
 if has('terminal')
   " Kill job and close terminal window


### PR DESCRIPTION
You can use `CTRL-g` instead of your custom mapping. 