### PR TITLE
Update typo in README (vimplug install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 
 # open vim and install all plugins
-:PLugInstall
+:PlugInstall
 
 # install tmux plugins
 git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm


### PR DESCRIPTION
vim-plug uses `:PlugInstall` to install the packages. I think there's a typo with it written as `:PLugInstall`