### PR TITLE
Update tmuxconf

### DIFF
--- a/tmuxconf
+++ b/tmuxconf
@@ -97,7 +97,7 @@ set -s escape-time 0
 set -g history-limit 1000000
 
 # Mouse mode on
-# set -g terminal-overrides 'xterm*:smcup@:rmcup@'
+# set -ga terminal-overrides 'xterm*:smcup@:rmcup@'
 set -g mouse on
 
 # Set title


### PR DESCRIPTION
`terminal-overrides` without the '-a' (append, don't overwrite) option.
It overwrites the config of `set-option -ga terminal-overrides ",xterm-256color:Tc"`