### PR TITLE
Fix incorrect ghosty directory name in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: sync
 sync:
 	mkdir -p ~/.config/fish
 	mkdir -p ~/.config/nvim
-	mkdir -p ~/.config/ghosty
+	mkdir -p ~/.config/ghostty
 
 	[ -f ~/.config/fish/config.fish ] || ln -s $(PWD)/config.fish ~/.config/fish/config.fish
 	[ -d ~/.config/fish/functions/ ] || ln -s $(PWD)/fish/functions ~/.config/fish/functions


### PR DESCRIPTION
It should be `ghostty` not `ghosty`. Soft links are correct.